### PR TITLE
chore: .gitignore に __pycache__ と pytest 関連を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 # Python
 .venv/
+__pycache__/
 
 # Ruff
 .ruff_cache
 
 # mypy
 .mypy_cache
+
+# pytest
+.pytest_cache
+.coverage


### PR DESCRIPTION
## Summary
- `__pycache__/` と pytest 関連（`.pytest_cache`, `.coverage`）を `.gitignore` に追加