### PR TITLE
feat: formatters/ モジュール実装

### DIFF
--- a/pythaw/formatters/__init__.py
+++ b/pythaw/formatters/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pythaw.formatters._base import Formatter
+from pythaw.formatters.concise import ConciseFormatter
+
+__all__ = ["ConciseFormatter", "Formatter", "get_formatter"]
+
+FORMATTERS: dict[str, Formatter] = {
+    "concise": ConciseFormatter(),
+}
+
+
+def get_formatter(name: str) -> Formatter | None:
+    """Return a formatter by name, or None if not found."""
+    return FORMATTERS.get(name)

--- a/pythaw/formatters/_base.py
+++ b/pythaw/formatters/_base.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pythaw.violation import Violation
+
+
+class Formatter(ABC):
+    """Base class for all output formatters."""
+
+    @abstractmethod
+    def format(self, violations: list[Violation]) -> str:
+        """Format violations into an output string."""

--- a/pythaw/formatters/concise.py
+++ b/pythaw/formatters/concise.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pythaw.formatters._base import Formatter
+
+if TYPE_CHECKING:
+    from pythaw.violation import Violation
+
+
+class ConciseFormatter(Formatter):
+    """Format violations as one-line-per-violation with a summary."""
+
+    def format(self, violations: list[Violation]) -> str:
+        if not violations:
+            return ""
+
+        lines = [f"{v.file}:{v.line}:{v.col}: {v.code} {v.message}" for v in violations]
+
+        file_count = len({v.file for v in violations})
+        violation_count = len(violations)
+        f_plural = "s" if file_count != 1 else ""
+        v_plural = "s" if violation_count != 1 else ""
+        summary = (
+            f"Found {violation_count} violation{v_plural}"
+            f" in {file_count} file{f_plural}."
+        )
+
+        lines.append("")
+        lines.append(summary)
+
+        return "\n".join(lines)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pythaw.formatters import ConciseFormatter, get_formatter
+from pythaw.violation import Violation
+
+
+class TestConciseFormatter:
+    """Verify concise format: 'file:line:col: code message' + summary line."""
+
+    def setup_method(self) -> None:
+        self.formatter = ConciseFormatter()
+
+    def test_single_violation(self) -> None:
+        violations = [
+            Violation(
+                file="handler.py",
+                line=15,
+                col=4,
+                code="PW001",
+                message="boto3.client() should be called at module scope",
+            ),
+        ]
+        result = self.formatter.format(violations)
+
+        expected = (
+            "handler.py:15:4: PW001 boto3.client() should be called at module scope\n"
+            "\n"
+            "Found 1 violation in 1 file."
+        )
+        assert result == expected
+
+    def test_multiple_violations_multiple_files(self) -> None:
+        violations = [
+            Violation(
+                file="handler.py",
+                line=15,
+                col=4,
+                code="PW001",
+                message="boto3.client() should be called at module scope",
+            ),
+            Violation(
+                file="handler.py",
+                line=23,
+                col=8,
+                code="PW002",
+                message="boto3.resource() should be called at module scope",
+            ),
+            Violation(
+                file="other.py",
+                line=10,
+                col=4,
+                code="PW001",
+                message="boto3.client() should be called at module scope",
+            ),
+        ]
+        result = self.formatter.format(violations)
+
+        expected = (
+            "handler.py:15:4: PW001 boto3.client() should be called at module scope\n"
+            "handler.py:23:8: PW002 boto3.resource() should be called at module scope\n"
+            "other.py:10:4: PW001 boto3.client() should be called at module scope\n"
+            "\n"
+            "Found 3 violations in 2 files."
+        )
+        assert result == expected
+
+    def test_no_violations(self) -> None:
+        result = self.formatter.format([])
+        assert result == ""
+
+
+class TestFormatterRegistry:
+    """Verify get_formatter() registry lookup."""
+
+    def test_get_concise_formatter(self) -> None:
+        formatter = get_formatter("concise")
+        assert isinstance(formatter, ConciseFormatter)
+
+    def test_get_unknown_formatter(self) -> None:
+        formatter = get_formatter("unknown")
+        assert formatter is None


### PR DESCRIPTION
## Summary
- Formatter ABC (`_base.py`) を追加
- concise 形式の `ConciseFormatter` を実装（`file:line:col: code message` + サマリー行）
- レジストリ (`get_formatter()`) を追加し、名前から Formatter を取得可能に
- テスト5件を追加（concise format / レジストリ）