### PR TITLE
feat: config モジュール実装

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ authors = [
     { name = "MiuraToya" }
 ]
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "tomli>=2.0.0; python_version < '3.11'",
+]
 
 [project.scripts]
 pythaw = "pythaw.cli:main"

--- a/pythaw/config.py
+++ b/pythaw/config.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+
+class ConfigError(Exception):
+    """Raised when configuration is invalid."""
+
+
+@dataclass(frozen=True)
+class Config:
+    """Project configuration loaded from pyproject.toml."""
+
+    handler_patterns: tuple[str, ...] = ("handler", "lambda_handler", "*_handler")
+    exclude: tuple[str, ...] = ()
+
+    @staticmethod
+    def load() -> Config:
+        """Load config from pyproject.toml.
+
+        Search for pyproject.toml in the current directory and parent
+        directories.  If not found, return default config.
+        """
+        toml_path = _find_pyproject()
+        if toml_path is None:
+            return Config()
+
+        try:
+            raw = toml_path.read_bytes()
+            data = tomllib.loads(raw.decode())
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            msg = f"Failed to read {toml_path}: {exc}"
+            raise ConfigError(msg) from exc
+
+        section: dict[str, Any] = data.get("tool", {}).get("pythaw", {})
+        if not section:
+            return Config()
+
+        return _build_config(section)
+
+
+def _find_pyproject() -> Path | None:
+    """Walk up from cwd looking for pyproject.toml."""
+    current = Path.cwd().resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _build_config(section: dict[str, Any]) -> Config:
+    """Construct a Config from the ``[tool.pythaw]`` mapping."""
+    kwargs: dict[str, Any] = {}
+
+    if "handler_patterns" in section:
+        kwargs["handler_patterns"] = _validate_str_list(
+            section["handler_patterns"],
+            "handler_patterns",
+        )
+
+    if "exclude" in section:
+        kwargs["exclude"] = _validate_str_list(section["exclude"], "exclude")
+
+    return Config(**kwargs)
+
+
+def _validate_str_list(value: object, name: str) -> tuple[str, ...]:
+    """Return *value* as a tuple of strings, or raise `ConfigError`."""
+    if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+        msg = f"tool.pythaw.{name} must be a list of strings"
+        raise ConfigError(msg)
+    return tuple(value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from pythaw.config import Config, ConfigError
+
+
+def _chdir(path: Path) -> Path:
+    """Change to *path* and return the previous working directory."""
+    original = Path.cwd()
+    os.chdir(path)
+    return original
+
+
+class TestConfigLoad:
+    """Verify Config.load() reads pyproject.toml via automatic discovery."""
+
+    def test_load_with_tool_pythaw_section(self, tmp_path: Path) -> None:
+        """Both handler_patterns and exclude are read correctly."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.pythaw]\nhandler_patterns = ["my_handler"]\nexclude = ["vendor/"]\n'
+        )
+        original = _chdir(tmp_path)
+        try:
+            cfg = Config.load()
+            assert cfg.handler_patterns == ("my_handler",)
+            assert cfg.exclude == ("vendor/",)
+        finally:
+            os.chdir(original)
+
+    def test_load_without_tool_pythaw_section(self, tmp_path: Path) -> None:
+        """Missing [tool.pythaw] section falls back to defaults."""
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'foo'\n")
+        original = _chdir(tmp_path)
+        try:
+            cfg = Config.load()
+            assert cfg.handler_patterns == ("handler", "lambda_handler", "*_handler")
+            assert cfg.exclude == ()
+        finally:
+            os.chdir(original)
+
+    def test_load_handler_patterns_only(self, tmp_path: Path) -> None:
+        """Only handler_patterns specified; exclude keeps its default."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.pythaw]\nhandler_patterns = ["entry"]\n'
+        )
+        original = _chdir(tmp_path)
+        try:
+            cfg = Config.load()
+            assert cfg.handler_patterns == ("entry",)
+            assert cfg.exclude == ()
+        finally:
+            os.chdir(original)
+
+    def test_load_exclude_only(self, tmp_path: Path) -> None:
+        """Only exclude specified; handler_patterns keeps its default."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.pythaw]\nexclude = ["tests/"]\n'
+        )
+        original = _chdir(tmp_path)
+        try:
+            cfg = Config.load()
+            assert cfg.handler_patterns == ("handler", "lambda_handler", "*_handler")
+            assert cfg.exclude == ("tests/",)
+        finally:
+            os.chdir(original)
+
+    def test_discovers_pyproject_in_parent(self, tmp_path: Path) -> None:
+        """Walks up parent directories to find pyproject.toml."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.pythaw]\nexclude = ["from_parent/"]\n'
+        )
+        child = tmp_path / "sub" / "dir"
+        child.mkdir(parents=True)
+        original = _chdir(child)
+        try:
+            cfg = Config.load()
+            assert cfg.exclude == ("from_parent/",)
+        finally:
+            os.chdir(original)
+
+    def test_no_pyproject_returns_default(self, tmp_path: Path) -> None:
+        """No pyproject.toml anywhere in the hierarchy falls back to defaults."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        original = _chdir(empty)
+        try:
+            cfg = Config.load()
+            assert cfg.handler_patterns == ("handler", "lambda_handler", "*_handler")
+            assert cfg.exclude == ()
+        finally:
+            os.chdir(original)
+
+
+class TestConfigValidation:
+    """Verify that invalid [tool.pythaw] values raise ConfigError."""
+
+    @pytest.mark.parametrize(
+        "toml_content",
+        [
+            "[tool.pythaw]\nhandler_patterns = 42\n",
+            '[tool.pythaw]\nhandler_patterns = ["ok", 1]\n',
+        ],
+    )
+    def test_handler_patterns_invalid(self, tmp_path: Path, toml_content: str) -> None:
+        """Non-string or non-list handler_patterns raises ConfigError."""
+        (tmp_path / "pyproject.toml").write_text(toml_content)
+        original = _chdir(tmp_path)
+        try:
+            with pytest.raises(ConfigError, match="handler_patterns must be a list"):
+                Config.load()
+        finally:
+            os.chdir(original)
+
+    @pytest.mark.parametrize(
+        "toml_content",
+        [
+            "[tool.pythaw]\nexclude = true\n",
+            '[tool.pythaw]\nexclude = ["ok", 1]\n',
+        ],
+    )
+    def test_exclude_invalid(self, tmp_path: Path, toml_content: str) -> None:
+        """Non-string or non-list exclude raises ConfigError."""
+        (tmp_path / "pyproject.toml").write_text(toml_content)
+        original = _chdir(tmp_path)
+        try:
+            with pytest.raises(ConfigError, match="exclude must be a list"):
+                Config.load()
+        finally:
+            os.chdir(original)
+
+    def test_invalid_toml_raises_config_error(self, tmp_path: Path) -> None:
+        """Malformed TOML syntax raises ConfigError."""
+        (tmp_path / "pyproject.toml").write_text("[tool.pythaw\n")
+        original = _chdir(tmp_path)
+        try:
+            with pytest.raises(ConfigError, match="Failed to read"):
+                Config.load()
+        finally:
+            os.chdir(original)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -11,6 +11,7 @@ class TestConciseFormatter:
         self.formatter = ConciseFormatter()
 
     def test_single_violation(self) -> None:
+        """Formats one violation with a '1 violation in 1 file' summary."""
         violations = [
             Violation(
                 file="handler.py",
@@ -30,6 +31,7 @@ class TestConciseFormatter:
         assert result == expected
 
     def test_multiple_violations_multiple_files(self) -> None:
+        """Formats violations across multiple files with correct summary counts."""
         violations = [
             Violation(
                 file="handler.py",
@@ -65,6 +67,7 @@ class TestConciseFormatter:
         assert result == expected
 
     def test_no_violations(self) -> None:
+        """Empty violation list returns empty string."""
         result = self.formatter.format([])
         assert result == ""
 
@@ -73,9 +76,11 @@ class TestFormatterRegistry:
     """Verify get_formatter() registry lookup."""
 
     def test_get_concise_formatter(self) -> None:
+        """'concise' key returns a ConciseFormatter instance."""
         formatter = get_formatter("concise")
         assert isinstance(formatter, ConciseFormatter)
 
     def test_get_unknown_formatter(self) -> None:
+        """Unknown key returns None."""
         formatter = get_formatter("unknown")
         assert formatter is None

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -27,12 +27,15 @@ class TestBoto3ClientRule:
         self.rule = Boto3ClientRule()
 
     def test_code(self) -> None:
+        """Rule code is PW001."""
         assert self.rule.code == "PW001"
 
     def test_message(self) -> None:
+        """Message describes the violation."""
         assert self.rule.message == "boto3.client() should be called at module scope"
 
     def test_match_boto3_client(self) -> None:
+        """Matches boto3.client() call."""
         node = _extract_call('boto3.client("s3")')
         assert self.rule.check(node) is True
 
@@ -45,6 +48,7 @@ class TestBoto3ClientRule:
         ],
     )
     def test_no_match(self, source: str) -> None:
+        """Does not match unrelated calls."""
         node = _extract_call(source)
         assert self.rule.check(node) is False
 
@@ -56,12 +60,15 @@ class TestBoto3ResourceRule:
         self.rule = Boto3ResourceRule()
 
     def test_code(self) -> None:
+        """Rule code is PW002."""
         assert self.rule.code == "PW002"
 
     def test_message(self) -> None:
+        """Message describes the violation."""
         assert self.rule.message == "boto3.resource() should be called at module scope"
 
     def test_match_boto3_resource(self) -> None:
+        """Matches boto3.resource() call."""
         node = _extract_call('boto3.resource("s3")')
         assert self.rule.check(node) is True
 
@@ -74,6 +81,7 @@ class TestBoto3ResourceRule:
         ],
     )
     def test_no_match(self, source: str) -> None:
+        """Does not match unrelated calls."""
         node = _extract_call(source)
         assert self.rule.check(node) is False
 
@@ -85,12 +93,15 @@ class TestBoto3SessionRule:
         self.rule = Boto3SessionRule()
 
     def test_code(self) -> None:
+        """Rule code is PW003."""
         assert self.rule.code == "PW003"
 
     def test_message(self) -> None:
+        """Message describes the violation."""
         assert self.rule.message == "boto3.Session() should be called at module scope"
 
     def test_match_boto3_session(self) -> None:
+        """Matches boto3.Session() call."""
         node = _extract_call("boto3.Session()")
         assert self.rule.check(node) is True
 
@@ -103,6 +114,7 @@ class TestBoto3SessionRule:
         ],
     )
     def test_no_match(self, source: str) -> None:
+        """Does not match unrelated calls."""
         node = _extract_call(source)
         assert self.rule.check(node) is False
 
@@ -111,6 +123,7 @@ class TestRegistry:
     """Verify get_all_rules() and get_rule() registry functions."""
 
     def test_get_all_rules(self) -> None:
+        """Returns all three built-in rules in order."""
         expected = (Boto3ClientRule, Boto3ResourceRule, Boto3SessionRule)
         rules = get_all_rules()
         assert tuple(type(r) for r in rules) == expected
@@ -124,8 +137,10 @@ class TestRegistry:
         ],
     )
     def test_get_rule_by_code(self, code: str, expected_type: type) -> None:
+        """Looks up each rule by its code."""
         rule = get_rule(code)
         assert isinstance(rule, expected_type)
 
     def test_get_rule_unknown_returns_none(self) -> None:
+        """Unknown code returns None."""
         assert get_rule("PW999") is None

--- a/uv.lock
+++ b/uv.lock
@@ -362,6 +362,9 @@ wheels = [
 name = "pythaw"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -372,6 +375,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- `pythaw/config.py`: `Config` dataclass と `ConfigError` を追加。`Config.load()` で cwd から `pyproject.toml` を自動探索し `[tool.pythaw]` セクションを読み込む
- `tomli` を Python 3.10 向け依存に追加
- 既存テスト (`test_rules.py`, `test_formatters.py`) にテスト関数の docstring を追加

## Test plan
- [x] `uv run pytest` 全 41 テストパス
- [x] `uv run mypy pythaw/config.py` エラーなし
- [x] `uv run ruff check .` エラーなし
- [x] `uv run ruff format --check .` エラーなし