### PR TITLE
test: E2E テストを拡充 (設定ファイル・サブコマンド・ハンドラーパターン)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ strict = true
 
 [tool.ruff]
 target-version = "py310"
+extend-exclude = ["tests/e2e/fixtures"]
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/tests/e2e/fixtures/async_handler/app.py
+++ b/tests/e2e/fixtures/async_handler/app.py
@@ -1,0 +1,7 @@
+"""NG: async ハンドラー内で boto3 を呼ぶパターン."""
+import boto3
+
+
+async def handler(event, context):
+    """非同期 Lambda ハンドラー."""
+    boto3.client("dynamodb")

--- a/tests/e2e/fixtures/clean/app.py
+++ b/tests/e2e/fixtures/clean/app.py
@@ -1,0 +1,9 @@
+"""OK: モジュールレベルで boto3.client を呼ぶパターン."""
+import boto3
+
+client = boto3.client("s3")
+
+
+def handler(event, context):
+    """Lambda ハンドラー."""
+    return client.get_object(Bucket="b", Key="k")

--- a/tests/e2e/fixtures/custom_patterns/app.py
+++ b/tests/e2e/fixtures/custom_patterns/app.py
@@ -1,0 +1,8 @@
+"""NG: カスタムパターン process_* にマッチするハンドラー."""
+import boto3
+
+
+def process_data(event, context):
+    """データ処理ハンドラー."""
+    client = boto3.client("s3")
+    return client.put_object(Bucket="b", Key="k", Body=event)

--- a/tests/e2e/fixtures/custom_patterns/pyproject.toml
+++ b/tests/e2e/fixtures/custom_patterns/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pythaw]
+handler_patterns = ["process_*"]

--- a/tests/e2e/fixtures/custom_patterns_no_default/app.py
+++ b/tests/e2e/fixtures/custom_patterns_no_default/app.py
@@ -1,0 +1,7 @@
+"""OK: デフォルトパターン handler はカスタム設定で無視される."""
+import boto3
+
+
+def handler(event, context):
+    """Lambda ハンドラー."""
+    boto3.client("s3")

--- a/tests/e2e/fixtures/custom_patterns_no_default/pyproject.toml
+++ b/tests/e2e/fixtures/custom_patterns_no_default/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pythaw]
+handler_patterns = ["process_*"]

--- a/tests/e2e/fixtures/exclude_dir/pyproject.toml
+++ b/tests/e2e/fixtures/exclude_dir/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pythaw]
+exclude = ["vendor"]

--- a/tests/e2e/fixtures/exclude_dir/vendor/lib.py
+++ b/tests/e2e/fixtures/exclude_dir/vendor/lib.py
@@ -1,0 +1,7 @@
+"""OK: vendor/ は exclude で除外される."""
+import boto3
+
+
+def handler(event, context):
+    """除外されるハンドラー."""
+    boto3.client("s3")

--- a/tests/e2e/fixtures/invalid_config_value/app.py
+++ b/tests/e2e/fixtures/invalid_config_value/app.py
@@ -1,0 +1,6 @@
+"""ダミーファイル."""
+
+
+def handler(event, context):
+    """Lambda ハンドラー."""
+    ...

--- a/tests/e2e/fixtures/invalid_config_value/pyproject.toml
+++ b/tests/e2e/fixtures/invalid_config_value/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pythaw]
+handler_patterns = "not_a_list"

--- a/tests/e2e/fixtures/invalid_toml/app.py
+++ b/tests/e2e/fixtures/invalid_toml/app.py
@@ -1,0 +1,6 @@
+"""ダミーファイル."""
+
+
+def handler(event, context):
+    """Lambda ハンドラー."""
+    ...

--- a/tests/e2e/fixtures/invalid_toml/pyproject.toml
+++ b/tests/e2e/fixtures/invalid_toml/pyproject.toml
@@ -1,0 +1,1 @@
+[tool.pythaw

--- a/tests/e2e/fixtures/multi_handler/multi.py
+++ b/tests/e2e/fixtures/multi_handler/multi.py
@@ -1,0 +1,13 @@
+"""NG: 複数ハンドラーがあるファイル."""
+import boto3
+
+
+def api_handler(event, context):
+    """API 用ハンドラー."""
+    boto3.client("s3")
+
+
+def event_handler(event, context):
+    """イベント処理用ハンドラー."""
+    session = boto3.Session()
+    sqs = session.client("sqs")

--- a/tests/e2e/fixtures/multi_violation/a.py
+++ b/tests/e2e/fixtures/multi_violation/a.py
@@ -1,0 +1,7 @@
+"""NG: handler 内で boto3.client を呼ぶ."""
+import boto3
+
+
+def handler(event, context):
+    """Lambda ハンドラー."""
+    boto3.client("s3")

--- a/tests/e2e/fixtures/multi_violation/b.py
+++ b/tests/e2e/fixtures/multi_violation/b.py
@@ -1,0 +1,7 @@
+"""NG: handler 内で boto3.resource を呼ぶ."""
+import boto3
+
+
+def lambda_handler(event, context):
+    """Lambda ハンドラー."""
+    boto3.resource("dynamodb")

--- a/tests/e2e/fixtures/nested_call/app.py
+++ b/tests/e2e/fixtures/nested_call/app.py
@@ -1,0 +1,12 @@
+"""NG: ネストされた関数内で boto3 を呼ぶパターン."""
+import boto3
+
+
+def lambda_handler(event, context):
+    """Lambda ハンドラー."""
+
+    def get_client():
+        return boto3.client("s3")
+
+    client = get_client()
+    return client.list_buckets()

--- a/tests/e2e/fixtures/non_handler/util.py
+++ b/tests/e2e/fixtures/non_handler/util.py
@@ -1,0 +1,8 @@
+"""OK: ハンドラーではないユーティリティファイル."""
+import boto3
+
+
+def process_data(data):
+    """データ処理（ハンドラーではない）."""
+    client = boto3.client("s3")
+    return client.put_object(Bucket="b", Key="k", Body=data)

--- a/tests/e2e/fixtures/violation/app.py
+++ b/tests/e2e/fixtures/violation/app.py
@@ -1,0 +1,8 @@
+"""NG: handler 内で boto3.client を呼ぶパターン."""
+import boto3
+
+
+def handler(event, context):
+    """Lambda ハンドラー."""
+    client = boto3.client("s3")
+    return client.list_buckets()


### PR DESCRIPTION
## Summary
- pyproject.toml 設定 (custom handler_patterns, exclude, 不正な TOML/値) の E2E テストを追加
- サブコマンドなし実行時の exit code 2 テストを追加
- 複数ハンドラー、async ハンドラー、ネスト呼び出し、非ハンドラー関数、存在しないパスなど多様なパターンの E2E テストを追加
- 既存 8 テスト → 19 テスト (11 テスト追加)

## Test plan
- [x] `uv run pytest tests/e2e/test_e2e.py -v` — 19 passed
- [x] `uv run ruff check` — All checks passed
- [x] `uv run ruff format --check` — Already formatted
- [x] `uv run mypy pythaw` — Success