### PR TITLE
fix: 違反出力のファイルパスを相対パスに変更

### DIFF
--- a/pythaw/checker.py
+++ b/pythaw/checker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import os
 from typing import TYPE_CHECKING
 
 from pythaw.finder import find_handlers
@@ -68,7 +69,7 @@ def _check_function(
     """Walk *func_node* and return violations for any matching Call nodes."""
     return [
         Violation(
-            file=str(file),
+            file=os.path.relpath(file),
             line=node.lineno,
             col=node.col_offset,
             code=rule.code,

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -32,13 +32,14 @@ class TestCheckE2E:
     """End-to-end tests for the 'check' subcommand."""
 
     def test_detects_violation_and_exits_1(self, tmp_path: Path) -> None:
-        """Violations produce concise output and exit code 1."""
+        """Violations produce concise output with relative paths and exit code 1."""
         cwd = _use_fixture("violation", tmp_path)
         result = _run_pythaw("check", ".", cwd=cwd)
         assert result.returncode == 1
         assert "PW001" in result.stdout
         assert "boto3.client()" in result.stdout
         assert "Found 1 violation in 1 file." in result.stdout
+        assert result.stdout.startswith("app.py:")
 
     def test_clean_code_exits_0(self, tmp_path: Path) -> None:
         """No violations produce no output and exit code 0."""

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from pythaw.checker import check
 from pythaw.config import Config
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _make_files(base: Path, files: dict[str, str]) -> None:
@@ -92,7 +89,7 @@ class TestCheckPositionInfo:
     """Verify that violations carry correct file, line, and column info."""
 
     def test_correct_position(self, tmp_path: Path) -> None:
-        """Violation points to the exact call location."""
+        """Violation points to the exact call location with a relative path."""
         source = (
             "import boto3\n"
             "\n"
@@ -104,7 +101,7 @@ class TestCheckPositionInfo:
             violations = check(tmp_path, Config())
         assert len(violations) == 1
         v = violations[0]
-        assert v.file == str((tmp_path / "app.py").resolve())
+        assert not Path(v.file).is_absolute()
         assert v.line == 4
         assert v.col == 13
 
@@ -128,4 +125,4 @@ class TestCheckEdgeCases:
         with patch("pythaw.finder._git_ls_files", return_value=None):
             violations = check(tmp_path, Config())
         assert len(violations) == 1
-        assert violations[0].file == str((tmp_path / "good.py").resolve())
+        assert not Path(violations[0].file).is_absolute()


### PR DESCRIPTION
## Summary
- 違反出力のファイルパスが絶対パスで表示されていたのを、CWD からの相対パスに変更
- ruff 等の一般的な lint ツールと同様の挙動に統一
- `checker.py` で `str(file)` → `os.path.relpath(file)` に変更

## Test plan
- [x] ユニットテスト: 相対パスが返ることを検証するアサーションに更新
- [x] E2E テスト: 出力が `app.py:` で始まることを検証するアサーション追加
- [x] 全 94 テスト通過、ruff / mypy クリア