### PR TITLE
feat: --select / --ignore オプション実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "commentTranslate.multiLineMerge": true,
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.analysis.extraPaths": ["${workspaceFolder}"]
+}

--- a/docs/ph2_todo.md
+++ b/docs/ph2_todo.md
@@ -1,7 +1,7 @@
 # Phase 2 実装 TODO
 
 - [ ] rules/pw004-pw009 — 追加ルール
-- [ ] cli.py — --select / --ignore
+- [x] cli.py — --select / --ignore
 - [ ] cli.py — --exit-zero / --statistics
 - [ ] formatters/json, github, sarif — 追加フォーマッター + --format
 - [ ] checker.py — インライン抑制 / ファイルレベル抑制

--- a/pythaw/cli.py
+++ b/pythaw/cli.py
@@ -43,6 +43,14 @@ def _build_parser() -> argparse.ArgumentParser:
 
     check_p = sub.add_parser("check", help="Check files for violations")
     check_p.add_argument("path", type=Path, help="File or directory to check")
+    check_p.add_argument(
+        "--select",
+        help="Comma-separated list of rule codes to enable",
+    )
+    check_p.add_argument(
+        "--ignore",
+        help="Comma-separated list of rule codes to disable",
+    )
     check_p.set_defaults(func=_cmd_check)
 
     rules_p = sub.add_parser("rules", help="List all built-in rules")
@@ -62,7 +70,9 @@ def _cmd_check(args: argparse.Namespace) -> int:
         print(str(exc), file=sys.stderr)
         return 2
 
-    violations = check(args.path, config)
+    select = tuple(args.select.split(",")) if args.select else None
+    ignore = tuple(args.ignore.split(",")) if args.ignore else None
+    violations = check(args.path, config, select=select, ignore=ignore)
 
     if not violations:
         print("All checks passed!")


### PR DESCRIPTION
## Summary
- `pythaw check --select PW001,PW002` で特定ルールのみ有効化
- `pythaw check --ignore PW003` で特定ルールを無効化
- 両方指定時は ignore が優先

## Test plan
- [x] checker ユニットテスト: select / ignore / 組み合わせ
- [x] CLI ユニットテスト: --select / --ignore オプション
- [x] 全 99 テスト通過、ruff / mypy クリア