### PR TITLE
chore: v0.3.0 にバージョンアップ

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythaw"
-version = "0.2.2"
+version = "0.3.0"
 description = "A Python static analysis tool that detects heavy initialization inside AWS Lambda handlers that should be moved to module scope for faster warm starts."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "pythaw"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary
- pyproject.toml のバージョンを 0.2.2 → 0.3.0 に更新
- uv.lock を同期

## Test plan
- [x] `uv lock` で正常に解決されることを確認