### PR TITLE
ci: タグ push 時に GitHub Release を自動作成

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -27,3 +27,7 @@ jobs:
         run: uvx --from dist/*.whl pythaw --help
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- publish.yml に GitHub Release 作成ステップを追加
- `--generate-notes` で前回タグからのマージ PR を自動でリリースノートに含める
- permissions を `contents: write` に変更（Release 作成に必要）

## Test plan
- [x] v0.3.0 タグ push 時に動作確認予定